### PR TITLE
feat: customize SIM_COUNTRY_ISO_OVERRIDE_STRING

### DIFF
--- a/app/src/main/java/io/github/vvb2060/ims/model/Feature.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/model/Feature.kt
@@ -14,6 +14,12 @@ enum class Feature(
         R.string.carrier_name_desc,
         "",
     ),
+    COUNTRY_ISO(
+        FeatureValueType.STRING,
+        R.string.country_iso,
+        R.string.country_iso_desc,
+        "",
+    ),
     VOLTE(
         FeatureValueType.BOOLEAN,
         R.string.volte,

--- a/app/src/main/java/io/github/vvb2060/ims/privileged/ImsModifier.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/privileged/ImsModifier.kt
@@ -30,6 +30,7 @@ class ImsModifier : Instrumentation() {
 
         fun buildBundle(
             carrierName: String?,
+            countryISO: String?,
             enableVoLTE: Boolean,
             enableVoWiFi: Boolean,
             enableVT: Boolean,
@@ -45,6 +46,15 @@ class ImsModifier : Instrumentation() {
                 bundle.putBoolean(CarrierConfigManager.KEY_CARRIER_NAME_OVERRIDE_BOOL, true)
                 bundle.putString(CarrierConfigManager.KEY_CARRIER_NAME_STRING, carrierName)
                 bundle.putString(CarrierConfigManager.KEY_CARRIER_CONFIG_VERSION_STRING, ":3")
+            }
+            // 运营商国家码
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                if (countryISO?.isNotBlank() ?: false) {
+                    bundle.putString(
+                        CarrierConfigManager.KEY_SIM_COUNTRY_ISO_OVERRIDE_STRING,
+                        countryISO
+                    )
+                }
             }
 
             // VoLTE 配置

--- a/app/src/main/java/io/github/vvb2060/ims/ui/MainActivity.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/ui/MainActivity.kt
@@ -384,6 +384,7 @@ fun FeaturesCard(
             val showFeatures = Feature.entries.toMutableList()
             if (!showCarrierName) {
                 showFeatures.remove(Feature.CARRIER_NAME)
+                showFeatures.remove(Feature.COUNTRY_ISO)
             }
             showFeatures.forEachIndexed { index, feature ->
                 val title = stringResource(feature.showTitleRes)

--- a/app/src/main/java/io/github/vvb2060/ims/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/io/github/vvb2060/ims/viewmodel/MainViewModel.kt
@@ -108,6 +108,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             val carrierName =
                 if (selectedSim.subId == -1) null else map[Feature.CARRIER_NAME] as String?
+            val countryISO =
+                if (selectedSim.subId == -1) null else map[Feature.COUNTRY_ISO] as String?
             val enableVoLTE = map.getOrDefault(Feature.VOLTE, true) as Boolean
             val enableVoWiFi = map.getOrDefault(Feature.VOWIFI, true) as Boolean
             val enableVT = map.getOrDefault(Feature.VT, true) as Boolean
@@ -119,6 +121,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
             val bundle = ImsModifier.buildBundle(
                 carrierName,
+                countryISO,
                 enableVoLTE,
                 enableVoWiFi,
                 enableVT,

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -25,6 +25,8 @@
     <string name="features_config">本次应用功能列表</string>
     <string name="carrier_name">运营商名称</string>
     <string name="carrier_name_desc">自定义运营商显示的名称，为空则不修改</string>
+    <string name="country_iso">运营商国家码</string>
+    <string name="country_iso_desc">自定义运营商国家码，为空则不修改</string>
     <string name="volte">VoLTE（4G 语音）</string>
     <string name="volte_desc">启用 4G 高清语音通话</string>
     <string name="vowifi">VoWiFi（WiFi 通话）</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="features_config">Features for this apply</string>
     <string name="carrier_name">Carrier Name</string>
     <string name="carrier_name_desc">Customize carrier name</string>
+    <string name="country_iso">Country ISO</string>
+    <string name="country_iso_desc">Customize country ISO code</string>
     <string name="volte">VoLTE (4G Voice)</string>
     <string name="volte_desc">Enable 4G HD voice calls</string>
     <string name="vowifi">VoWiFi (WiFi Calling)</string>


### PR DESCRIPTION
add feature for customizing ``KEY_SIM_COUNTRY_ISO_OVERRIDE_STRING`` for spoofing the country code for some apps.